### PR TITLE
Add basic tests and enforce PEP8 style

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -1,11 +1,12 @@
-from Node import *
+from Node import Node, creationarbre
 from bitarray import bitarray
 import os
 import argparse
 
 
 def alphabet_frequency(nom_fichier) -> dict:
-    """Renvoies un dictionnaire comportant les caractères du texte dans l'ordre de fréquence croissante puis si deux caractères ont le même nombre d'apparition, par leur ordre dans l'alphabet ASCII
+    """Renvoie un dictionnaire des caractères du texte classés par fréquence
+    croissante, puis par ordre ASCII en cas d'égalité.
 
     Args:
         nom_fichier (string): fichier qui contient le texte
@@ -17,9 +18,9 @@ def alphabet_frequency(nom_fichier) -> dict:
         reader = f.read()
     alphabet = dict()
     for caractere in reader:
-        try:
+        if caractere in alphabet:
             alphabet[caractere] += 1
-        except:
+        else:
             alphabet[caractere] = 1
     alphabet_tri = dict(sorted(alphabet.items(), key=lambda x: x[0]))
     alphabet_tri = dict(sorted(alphabet_tri.items(), key=lambda x: x[1]))
@@ -42,11 +43,12 @@ def list_to_string(liste):
 
 
 def text_to_bitarray(nom_fichier, binary_dict):
-    """transforme un text en une suite de bits
+    """Transforme un texte en une suite de bits.
 
     Args:
-        nom_fichier (string): le nom du fichier
-        binary_dict (dict): le dictionnaire qui contient la correspondance entre le caractère brut et le caractère en binaire
+        nom_fichier (string): nom du fichier
+        binary_dict (dict): dictionnaire associant chaque caractère à son code
+            binaire
 
     Returns:
         bitarray: une suite de bits qui représente le texte
@@ -57,9 +59,9 @@ def text_to_bitarray(nom_fichier, binary_dict):
     for char in reader:
         string_list += [binary_dict[char]]
     bit_list = []
-    for str in string_list:
-        for bit in str:
-            bit_list += [int(bit)]
+    for token in string_list:
+        for bit in token:
+            bit_list.append(int(bit))
     bits = bitarray(bit_list)
     return bits
 
@@ -88,10 +90,13 @@ def lengthonbit(fichierbase, fichiercompresse):
         reader = f.read()
     length = len(reader)
     taillecompresse = os.path.getsize(fichiercompresse)
-    # pour passer de octet/caractère à bit/caractère, il faut diviser par 8 le résultat
-    bit_par_caractère = taillecompresse/length/8
+    # pour passer de octet/caractère à bit/caractère on divise par 8
+    bit_par_caractere = taillecompresse / length / 8
     print(
-        f'le nombre moyen de bit de stockage par caractère est : {bit_par_caractère} bits')
+        "le nombre moyen de bit de stockage par caractère est : "
+        f"{bit_par_caractere} bits"
+    )
+
 
 def compress(nom_fichier):
     """Compresse un fichier texte en utilisant l'algorithme de Huffman."""
@@ -103,7 +108,10 @@ def compress(nom_fichier):
     arbre = creationarbre(liste_feuilles)[0]
 
     parcours_profondeur = arbre.parcours_profondeur()
-    new_alphabet = {result[0]: list_to_string(result[2]) for result in parcours_profondeur}
+    new_alphabet = {
+        result[0]: list_to_string(result[2])
+        for result in parcours_profondeur
+    }
 
     texte_compresse = text_to_bitarray(nom_fichier, new_alphabet)
     with open(nom_fichier[:-4] + '_comp.bin', 'wb') as new_file:
@@ -119,10 +127,15 @@ def compress(nom_fichier):
 
     compare_size(nom_fichier, nom_fichier[:-4] + '_comp.bin')
 
-    nb_bits = sum(len(new_alphabet[key]) * alphabet[key] for key in liste_caracteres)
+    nb_bits = sum(
+        len(new_alphabet[key]) * alphabet[key]
+        for key in liste_caracteres
+    )
     nb_caracteres_total = sum(alphabet[key] for key in liste_caracteres)
     print(
-        f"le nombre moyen de bits de stockage par caractères est : {nb_bits / nb_caracteres_total} bits")
+        "le nombre moyen de bits de stockage par caractères est : "
+        f"{nb_bits / nb_caracteres_total} bits"
+    )
 
 
 def decompress(nom_fichier):
@@ -169,10 +182,23 @@ def decompress(nom_fichier):
     print(f'Fichier d\xE9compress\xE9 \xE9crit dans {output_file}')
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Compression et d\xE9compression Huffman')
-    parser.add_argument('fichier', help='Fichier texte (pour la compression) ou nom de base (pour la d\xE9compression)')
-    parser.add_argument('-d', '--decompress', action='store_true', help='D\xE9compresser le fichier sp\xE9cifi\xE9')
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Compression et d\xE9compression Huffman"
+    )
+    parser.add_argument(
+        "fichier",
+        help=(
+            "Fichier texte (pour la compression) ou nom de base "
+            "(pour la d\xE9compression)"
+        ),
+    )
+    parser.add_argument(
+        "-d",
+        "--decompress",
+        action="store_true",
+        help="D\xE9compresser le fichier sp\xE9cifi\xE9",
+    )
     args = parser.parse_args()
 
     if args.decompress:

--- a/Node.py
+++ b/Node.py
@@ -1,12 +1,19 @@
 class Node:
-    def __init__(self, frequency, label=None, left_child=None, right_child=None) -> None:
-        """Un noeud contient la fréquence d'apparition du caractère qu'il représente si c'est une feuille sinon, l'addtition de la fréquence d'apparition de ses deux fils
+    def __init__(
+        self,
+        frequency,
+        label=None,
+        left_child=None,
+        right_child=None,
+    ) -> None:
+        """Représente un nœud de l'arbre de Huffman.
 
         Args:
-            frequency (int): la fréquence d'apparition du caractère si c'est une feuille, la somme de celle de ses deux fils sinon
-            label (string, optional): caractère contenu dans la feuille. Defaults to None.
-            left_child (Node, optional): le fils de gauche. Defaults to None.
-            right_child (Node, optional): le fils de droite. Defaults to None.
+            frequency (int): fréquence d'apparition du caractère si c'est une
+                feuille, somme des fréquences des deux fils sinon.
+            label (str, optional): caractère contenu dans la feuille.
+            left_child (Node, optional): fils de gauche.
+            right_child (Node, optional): fils de droite.
         """
         self.frequency = frequency
         self.label = label
@@ -14,39 +21,34 @@ class Node:
         self.right_child = right_child
 
     def is_leaf(self):
-        """vérifies si le noeud est une feuill
-
-        Returns:
-            Bool: True si c'est une feuille, False sinon
-        """
-        if self.left_child == None and self.right_child == None:
-            return True
-        else:
-            return False
+        """Retourne ``True`` si le nœud est une feuille."""
+        return self.left_child is None and self.right_child is None
 
     def parcours_profondeur(self, encodage=None):
-        """Parcours l'arbre en profondeur afin de renvoyer la représentation binaire de chaque caractères
+        """Parcourt l'arbre en profondeur pour obtenir le code binaire des
+        caractères.
 
         Args:
-            encodage (list, optional): permet de garder en mémoire le chemin parcourue sous forme de 0 et de 1. Defaults to None.
+            encodage (list, optional): chemin parcouru sous forme de ``0`` ou
+                ``1``. Defaults to ``None``.
 
         Returns:
-            list: Une liste de liste contenant le caractère, sa fréquence ainsi que sa représentation en binaire
+            list: liste ``[caractère, fréquence, code_binaire]``
         """
         if encodage is None:
             encodage = []
-            
-        if self.is_leaf() == True:
+
+        if self.is_leaf():
             result = encodage[:]
             return [[self.label, self.frequency, result]]
+
         gauche = []
         droite = []
-        if self.left_child != None:
+        if self.left_child is not None:
             gauche = self.left_child.parcours_profondeur(encodage + [0])
-        if self.right_child != None:
+        if self.right_child is not None:
             droite = self.right_child.parcours_profondeur(encodage + [1])
-        # return [encodage[:]+[self.frequency]]+gauche+droite
-        return gauche+droite
+        return gauche + droite
 
 
 def deuxpetits(liste_node) -> list:

--- a/tests/test_huffman.py
+++ b/tests/test_huffman.py
@@ -1,0 +1,39 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from Node import Node, creationarbre
+import Main
+
+
+def test_is_leaf():
+    leaf = Node(1, 'a')
+    assert leaf.is_leaf() is True
+    parent = Node(2, left_child=leaf, right_child=Node(1, 'b'))
+    assert parent.is_leaf() is False
+
+
+def test_parcours_profondeur():
+    left = Node(1, 'a')
+    right = Node(1, 'b')
+    root = Node(2, left_child=left, right_child=right)
+    codes = root.parcours_profondeur()
+    result = {label: code for label, _, code in codes}
+    assert result['a'] == [0]
+    assert result['b'] == [1]
+
+
+def test_compress_decompress(tmp_path):
+    text_file = tmp_path / 'sample.txt'
+    text_file.write_text('ababa')
+    Main.compress(str(text_file))
+    Main.decompress(str(text_file))
+
+    output_file = tmp_path / 'sample_decomp.txt'
+    assert output_file.read_text() == 'ababa'
+
+    # ensure intermediate files were created
+    assert (tmp_path / 'sample_comp.bin').exists()
+    assert (tmp_path / 'sample_freq.txt').exists()


### PR DESCRIPTION
## Summary
- fix PEP 8 issues in `Node.py` and `Main.py`
- replace wildcard import and avoid bare except
- wrap long lines and add spacing
- add regression tests for Huffman tree and compression/decompression

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f6768da54833087cfcb22fa53dad1